### PR TITLE
Adding keys to Kafka messages sent to topic-mission-event and topic-r…

### DIFF
--- a/src/main/java/com/redhat/cajun/navy/mission/http/MissionRestVerticle.java
+++ b/src/main/java/com/redhat/cajun/navy/mission/http/MissionRestVerticle.java
@@ -184,7 +184,8 @@ public class MissionRestVerticle extends CacheAccessVerticle {
         mc.createMissionCommandHeaders(event.getMessageType());
         mc.setMission(m);
 
-        DeliveryOptions options = new DeliveryOptions().addHeader("action", MessageAction.PUBLISH_UPDATE.toString());
+        DeliveryOptions options = new DeliveryOptions().addHeader("action", MessageAction.PUBLISH_UPDATE.toString())
+                .addHeader("key", m.getIncidentId());
         vertx.eventBus().send(PUB_QUEUE, mc.toString(), options, reply -> {
             if (reply.succeeded()) {
                 System.out.println("Message publish request accepted");
@@ -199,7 +200,8 @@ public class MissionRestVerticle extends CacheAccessVerticle {
     private void sendUpdate(Responder responder, MessageType event, boolean available) {
         // Possible issue here, since DG might not be updated and this message is publised for Mission Created.
         ResponderCommand rc = new ResponderCommand(responder, event.getMessageType());
-        DeliveryOptions options = new DeliveryOptions().addHeader("action", MessageAction.RESPONDER_UPDATE.toString());
+        DeliveryOptions options = new DeliveryOptions().addHeader("action", MessageAction.RESPONDER_UPDATE.toString())
+                .addHeader("key", responder.getResponderId());
 
         vertx.eventBus().send(PUB_QUEUE, rc.getResponderCommand(available), options, reply -> {
             if (reply.succeeded()) {

--- a/src/main/java/com/redhat/cajun/navy/mission/message/MissionProducerVerticle.java
+++ b/src/main/java/com/redhat/cajun/navy/mission/message/MissionProducerVerticle.java
@@ -29,13 +29,14 @@ public class MissionProducerVerticle extends MissionMessageVerticle {
 
 
         String action = message.headers().get("action");
+        String key = message.headers().get("key");
         switch (action) {
             case "PUBLISH_UPDATE":
-                sendMessage(missionUpdateCommandTopic, String.valueOf(message.body()));
+                sendMessage(missionUpdateCommandTopic, key, String.valueOf(message.body()));
                 message.reply("Message sent "+missionUpdateCommandTopic);
                 break;
             case "RESPONDER_UPDATE":
-                sendMessage(responderUpdateTopic, String.valueOf(message.body()));
+                sendMessage(responderUpdateTopic, key, String.valueOf(message.body()));
                 message.reply("Message Sent "+responderUpdateTopic);
                 break;
 
@@ -46,10 +47,10 @@ public class MissionProducerVerticle extends MissionMessageVerticle {
     }
 
 
-    public void sendMessage(String topic, String body){
+    public void sendMessage(String topic, String key, String body){
 
         KafkaProducerRecord<String, String> record =
-                KafkaProducerRecord.create(topic, body);
+                KafkaProducerRecord.create(topic, key, body);
 
         producer.write(record, done -> {
             if (done.succeeded()) {


### PR DESCRIPTION
…esponder-event

Kafka messages should have a key to guarantee strict ordered consumption of messages, especially when scaling out consumers. Messages with the same key will always be handled by the same Kafka partition, and hence the same Kafka consumers. This ensure that messages with the same key are consumed in the correct order. 